### PR TITLE
Adds "font-display: swap" CSS property for google fonts.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -142,7 +142,7 @@ function foodhunt_scripts() {
 
 	wp_enqueue_style( 'foodhunt-style', get_stylesheet_uri() );
 
-	wp_enqueue_style( 'foodhunt-google-font', '//fonts.googleapis.com/css?family=Lato:400,300,700|Great+Vibes' );
+	wp_enqueue_style( 'foodhunt-google-font', '//fonts.googleapis.com/css?family=Lato:400,300,700|Great+Vibes&display=swap' );
 
 	wp_enqueue_style( 'font-awesome', esc_url( get_template_directory_uri() ) . '/font-awesome/css/font-awesome' . $suffix . '.css', array(), '4.7.0' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -74,8 +74,7 @@ and we will include it within the theme from next version update.
 = Version TBD =
 * Feature - Added RTL support.
 * Tweak - Update screenshot image source link.
-* Enhancement - Added 'font-display: swap' CSS property for fonts to ensure better load performance.
-
+* Enhancement - Added CSS font-display property and swap value for better performance.
 
 = Version 1.3.2 2021-02-24 =
 * Tweak - Update Screenshot Image.

--- a/readme.txt
+++ b/readme.txt
@@ -74,6 +74,8 @@ and we will include it within the theme from next version update.
 = Version TBD =
 * Feature - Added RTL support.
 * Tweak - Update screenshot image source link.
+* Enhancement - Added 'font-display: swap' CSS property for fonts to ensure better load performance.
+
 
 = Version 1.3.2 2021-02-24 =
 * Tweak - Update Screenshot Image.


### PR DESCRIPTION
### Changes proposed in this Pull Request
>Adds 'font-display:swap' CSS property for fonts. This ensures that our fonts remains visible and also ensures better load performance.
### Type of change
- [ ] Code Refactor
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test the changes in this Pull Request:
1. Use google inbuilt tool "Light House".
2. Change fonts options from the customizer.
3. There must not be any error related to fonts that say "Ensure fonts remains visible during page reload".

### Checklist:
- [x] My code follows WordPress' coding standards
- [ ] I've checked to ensure there are no other open Pull Requests for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have made perform a test that proves my fix is effective or that my feature works
### Did you test this issue fix on all browsers?
- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] opera
### Changelog entry
> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.